### PR TITLE
Adding support for custom HTTP headers and cookies in the post streaming_subscribe method.

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -130,27 +130,29 @@ class Viewpoint::EWS::Connection
   #   the response.
   def post(xmldoc, options: {})
     headers = {'Content-Type' => 'text/xml'}
-    headers.merge!(custom_http_headers(options[:request_options])) if options[:customisable_headers]
-    set_custom_http_cookies(options[:request_options]) if options[:customisable_cookies]
+    headers.merge!(custom_http_headers(options[:customisable_headers])) if options[:customisable_headers]
+    set_custom_http_cookies(options[:customisable_cookies]) if options[:customisable_cookies]
 
     check_response( @httpcli.post(@endpoint, xmldoc, headers) )
   end
 
-  def custom_http_headers(request_options)
-    Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS.inject({}) do |header_hash, header_key, header_name|
-      if request_options.include?(header_key)
-        header_hash[header_name] = request_options[header_key]
-        header_hash
+  def custom_http_headers(headers)
+    custom_headers = Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS.inject({}) do |header_hash, (header_key, header_name)|
+      if headers.include?(header_key)
+        header_hash[header_name] = headers[header_key]
       end
-    end # check for nil (e.g. when no CUSTOMISABLE_HTTP_HEADERS exist)
+      header_hash
+    end
+
+    custom_headers || {}
   end
 
-  def set_custom_http_cookies(request_options)
+  def set_custom_http_cookies(cookies)
     Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_COOKIES.each do |cookie_key, cookie_name|
-      if request_options.include?(cookie_key)
+      if cookies.include?(cookie_key)
         cookie = WebAgent::Cookie.new
         cookie.name = cookie_name
-        cookie.value = request_options[cookie_key]
+        cookie.value = cookies[cookie_key]
         cookie.url = URI(endpoint)
         @httpcli.cookie_manager.add(cookie)
       end

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -129,21 +129,20 @@ class Viewpoint::EWS::Connection
   # @return [String] If the request is successful (200) it returns the body of
   #   the response.
   def post(xmldoc, options: {})
-    @http_headers = {'Content-Type' => 'text/xml'}
-    if options[:request_options]
-      set_custom_http_headers(options[:request_options])
-      set_custom_http_cookies(options[:request_options])
-    end
+    headers = {'Content-Type' => 'text/xml'}
+    headers.merge!(custom_http_headers(options[:request_options])) if options[:customisable_headers]
+    set_custom_http_cookies(options[:request_options]) if options[:customisable_cookies]
 
-    check_response( @httpcli.post(@endpoint, xmldoc, @http_headers ) )
+    check_response( @httpcli.post(@endpoint, xmldoc, headers) )
   end
 
-  def set_custom_http_headers(request_options)
-    Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS.each do |header_key, header_name|
+  def custom_http_headers(request_options)
+    Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS.inject({}) do |header_hash, header_key, header_name|
       if request_options.include?(header_key)
-        @http_headers.merge!({header_name => request_options[header_key]})
+        header_hash[header_name] = request_options[header_key]
+        header_hash
       end
-    end
+    end # check for nil (e.g. when no CUSTOMISABLE_HTTP_HEADERS exist)
   end
 
   def set_custom_http_cookies(request_options)

--- a/lib/ews/soap.rb
+++ b/lib/ews/soap.rb
@@ -64,6 +64,14 @@ module Viewpoint
       SOFT_DELETE = 'SoftDelete'
       MOVE_TO_DELETED_ITEMS = 'MoveToDeletedItems'
 
+      CUSTOMISABLE_HTTP_HEADERS = {
+        anchor_mailbox: "X-AnchorMailbox",
+        prefer_server_affinity: "X-PreferServerAffinity"
+      }.freeze
+      CUSTOMISABLE_HTTP_COOKIES = {
+        backend_override_cookie: "X-BackEndOverrideCookie"
+      }.freeze
+
       def initialize
         @log = Logging.logger[self.class.name.to_s.to_sym]
         @default_ns = NAMESPACES["xmlns:#{NS_EWS_MESSAGES}"]

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -47,6 +47,12 @@ module Viewpoint::EWS::SOAP
     #       }},
     #       ]
     def subscribe(subscriptions)
+      byebug
+      # subscriptions.map[:]
+      # request_options: {
+      #   headers: subscriptions[:]
+      # }
+
       req = build_soap! do |type, builder|
         if(type == :header)
         else
@@ -63,7 +69,7 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      do_soap_request(req, response_class: EwsResponse, options: request_options)
     end
 
     # End a pull notification subscription.
@@ -169,9 +175,13 @@ module Viewpoint::EWS::SOAP
     # @param evtypes [Array] the events you would like to subscribe to.
     # @param timeout [Fixnum] http://msdn.microsoft.com/en-us/library/aa565201.aspx
     # @param watermark [String] http://msdn.microsoft.com/en-us/library/aa565886.aspx
-    def stream_subscribe_folder(folder, evtypes, timeout = nil, watermark = nil)
+    # @param options [Hash]
+    def stream_subscribe_folder(folder, evtypes, timeout = nil, watermark = nil, options: {})
       timeout ||= 30 # Streaming default timeout 30 mins
       psr = {
+        :anchor_mailbox => options[:anchor_mailbox],
+        :prefer_server_affinity => options[:prefer_server_affinity] || false,
+        :backend_override_cookie => options[:backend_override_cookie],
         :subscribe_to_all_folders => false,
         :folder_ids => [ {:id => folder[:id], :change_key => folder[:change_key]} ],
         :event_types=> evtypes,

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -49,7 +49,7 @@ module Viewpoint::EWS::SOAP
     def subscribe(subscriptions, options: {})
       options = {
         customisable_headers: get_customisable_headers(options) || {},
-        customisable_cookies: get_customisable_cookies(options || {})
+        customisable_cookies: get_customisable_cookies(options) || {}
       }
 
       req = build_soap! do |type, builder|
@@ -72,15 +72,11 @@ module Viewpoint::EWS::SOAP
     end
 
     def get_customisable_headers(options)
-      options.reject do |option, _|
-        !CUSTOMISABLE_HTTP_HEADERS.include?(option)
-      end
+      options.reject { |option, _| !CUSTOMISABLE_HTTP_HEADERS.include?(option) }
     end
 
     def get_customisable_cookies(options)
-      options.reject do |option, _|
-        !CUSTOMISABLE_HTTP_COOKIES.include?(option)
-      end
+      options.reject { |option, _| !CUSTOMISABLE_HTTP_COOKIES.include?(option) }
     end
 
     # End a pull notification subscription.

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -47,10 +47,8 @@ module Viewpoint::EWS::SOAP
     #       }},
     #       ]
     def subscribe(subscriptions, options: {})
-      options = {
-        customisable_headers: get_customisable_headers(options) || {},
-        customisable_cookies: get_customisable_cookies(options) || {}
-      }
+      customisable_headers = get_customisable_headers(options) || {}
+      customisable_cookies = get_customisable_cookies(options) || {}
 
       req = build_soap! do |type, builder|
         if(type == :header)
@@ -68,7 +66,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse, options: options)
+      do_soap_request(req,
+        response_class: EwsResponse,
+        customisable_headers: customisable_headers,
+        customisable_cookies: customisable_cookies
+      )
     end
 
     def get_customisable_headers(options)

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -47,7 +47,10 @@ module Viewpoint::EWS::SOAP
     #       }},
     #       ]
     def subscribe(subscriptions, options: {})
-      request_options = get_request_options(options)
+      options = {
+        customisable_headers: get_customisable_headers(options) || {},
+        customisable_cookies: get_customisable_cookies(options || {})
+      }
 
       req = build_soap! do |type, builder|
         if(type == :header)
@@ -65,15 +68,18 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse, request_options: request_options)
+      do_soap_request(req, response_class: EwsResponse, options: options)
     end
 
-    def get_request_options(options)
-      options.inject({}) do |result, (option, value)|
-        if CUSTOMISABLE_HTTP_HEADERS.include?(option) || CUSTOMISABLE_HTTP_COOKIES.include?(option)
-          result[option] = value
-        end
-        result
+    def get_customisable_headers(options)
+      options.reject do |option, _|
+        !CUSTOMISABLE_HTTP_HEADERS.include?(option)
+      end
+    end
+
+    def get_customisable_cookies(options)
+      options.reject do |option, _|
+        !CUSTOMISABLE_HTTP_COOKIES.include?(option)
       end
     end
 

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -52,6 +52,7 @@ module Viewpoint::EWS::Types
     # @param [SOAP::ExchangeWebService] ews the EWS reference
     # @param [Hash] ews_item the EWS parsed response document
     def initialize(ews, ews_item)
+      byebug
       super
       simplify!
       @sync_state = nil
@@ -272,13 +273,14 @@ module Viewpoint::EWS::Types
     # @param timeout [Fixnum] the time in minutes that the subscription can
     #   remain idle between calls to #get_events. default: 240 minutes
     # @return [Boolean] Did the subscription happen successfully?
-    def streaming_subscribe(evtypes = [:all], watermark = nil, timeout = 240)
+    def streaming_subscribe(evtypes = [:all], watermark = nil, timeout = 240, options: {})
+      byebug
       # Refresh the subscription if already subscribed
       unsubscribe if streaming_subscribed?
 
       event_types = normalize_event_names(evtypes)
       folder = {id: self.id, change_key: self.change_key}
-      resp = ews.stream_subscribe_folder(folder, event_types, timeout, watermark)
+      resp = ews.stream_subscribe_folder(folder, event_types, timeout, watermark, options: options)
       rmsg = resp.response_messages.first
       if rmsg.success?
         @subscription_id = rmsg.subscription_id

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -52,7 +52,6 @@ module Viewpoint::EWS::Types
     # @param [SOAP::ExchangeWebService] ews the EWS reference
     # @param [Hash] ews_item the EWS parsed response document
     def initialize(ews, ews_item)
-      byebug
       super
       simplify!
       @sync_state = nil
@@ -274,7 +273,6 @@ module Viewpoint::EWS::Types
     #   remain idle between calls to #get_events. default: 240 minutes
     # @return [Boolean] Did the subscription happen successfully?
     def streaming_subscribe(evtypes = [:all], watermark = nil, timeout = 240, options: {})
-      byebug
       # Refresh the subscription if already subscribed
       unsubscribe if streaming_subscribed?
 

--- a/spec/ews/connection_spec.rb
+++ b/spec/ews/connection_spec.rb
@@ -1,0 +1,129 @@
+require "spec_helper"
+
+describe Viewpoint::EWS::Connection do
+  let(:endpoint) { "https://endpoint.com/exchange.asmx" }
+  let(:connection) { described_class.new(endpoint) }
+  let(:anchor_mailbox) { "mailbox@example.com" }
+  let(:prefer_server_affinity) { true }
+  let(:backend_override_cookie) { "cookie" }
+  let(:request_options) {
+    {
+      anchor_mailbox: anchor_mailbox,
+      prefer_server_affinity: prefer_server_affinity,
+      backend_override_cookie: backend_override_cookie
+    }
+  }
+
+  describe "#post" do
+    let(:options) { {} }
+    let(:xmldoc) { double(:xmldoc) }
+
+    before do
+      allow(connection).to receive(:check_response)
+    end
+
+    subject { connection.post(xmldoc, options: options) }
+
+    context "when request options are passed in" do
+      let(:options) { { request_options: request_options } }
+
+      it "sets the custom HTTP headers and cookies" do
+        expect(connection).to receive(:set_custom_http_headers).with(request_options)
+        expect(connection).to receive(:set_custom_http_cookies).with(request_options)
+
+        subject
+      end
+    end
+
+    context "when no request options are passed in" do
+      it "doesn't set the HTTP headers and cookies" do
+        expect(connection).not_to receive(:set_custom_http_headers)
+        expect(connection).not_to receive(:set_custom_http_cookies)
+
+        subject
+      end
+    end
+  end
+
+  describe "#set_custom_http_headers" do
+    let(:existing_http_headers) { { "some_header" => "some_value" } }
+
+    before { connection.instance_variable_set(:@http_headers, existing_http_headers) }
+    subject { connection.set_custom_http_headers(request_options) }
+
+    context "when custom HTTP headers are passed in" do
+
+      it "merges to the existing HTTP headers" do
+        subject
+        expect(connection.instance_variable_get(:@http_headers)).to eq(
+          {
+            "some_header" => "some_value",
+            Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS[:anchor_mailbox] => anchor_mailbox,
+            Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS[:prefer_server_affinity] => prefer_server_affinity
+          }
+        )
+      end
+    end
+
+    context "when no custom HTTP headers are passed in" do
+      let(:request_options) { {} }
+
+      it "doesn't change the HTTP headers" do
+        subject
+        expect(connection.instance_variable_get(:@http_headers)).to eq(existing_http_headers)
+      end
+    end
+  end
+
+  describe "#set_custom_http_cookies" do
+    subject { connection.set_custom_http_cookies(request_options) }
+
+    context "when custom HTTP cookies are passed in" do
+      # Using an OpenStruct object instead of a double because the name attribute
+      # is being overwritten in the set_custom_http_cookies method, and it's
+      # going to clash with the double's built-in name method.
+      let(:backend_override_cookie_object) { OpenStruct.new(name: nil, value: nil, url: nil) }
+
+      it "adds a new cookie to the HTTP cookie manager" do
+        httpcli = connection.instance_variable_get(:@httpcli)
+        expect(WebAgent::Cookie).to receive(:new) { backend_override_cookie_object }
+        allow(backend_override_cookie_object).to receive(:name)
+          .with(Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_HEADERS[:backend_override_cookie])
+        allow(backend_override_cookie_object).to receive(:value)
+          .with(backend_override_cookie)
+        allow(backend_override_cookie_object).to receive(:url).with(
+            URI(connection.endpoint)
+          )
+        expect(httpcli.cookie_manager).to receive(:add).with(
+          backend_override_cookie_object
+        )
+
+        subject
+      end
+    end
+
+    context "when no custom HTTP cookies are passed in" do
+      let(:request_options) { {} }
+
+      it "doesn't add a new cookie to the HTTP cookie manager" do
+        httpcli = connection.instance_variable_get(:@httpcli)
+        expect(WebAgent::Cookie).not_to receive(:new)
+        expect(httpcli.cookie_manager).not_to receive(:add)
+
+        subject
+      end
+    end
+  end
+
+#   +  def set_custom_http_cookies(request_options)
+# +    Viewpoint::EWS::SOAP::CUSTOMISABLE_HTTP_COOKIES.each do |cookie_key, cookie_name|
+# +      if request_options.include?(cookie_key)
+# +        cookie = WebAgent::Cookie.new
+# +        cookie.name = cookie_name
+# +        cookie.value = request_options[cookie_key]
+# +        cookie.url = URI(endpoint)
+# +        @httpcli.cookie_manager.add(cookie)
+# +      end
+# +    end
+#    end	   end
+end

--- a/spec/ews/soap/exchange_notification_spec.rb
+++ b/spec/ews/soap/exchange_notification_spec.rb
@@ -11,48 +11,69 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
     let(:options) { { anchor_mailbox: "mailbox@example.com"} }
     let(:req_double) { double(:request) }
     let(:subscriptions) { double(:subscriptions) }
+    let(:customisable_headers) { { some_header: "some_value" } }
+    let(:customisable_cookies) { { some_cookie: "some_other_value" } }
 
     subject { test_instance.subscribe(subscriptions, options: options) }
 
-    it "passes the request options to the do_soap_request method" do
-      expect(test_instance).to receive(:get_request_options).with(options) { options }
+    it "passes the customisable_cookies and customisable_headers options to the do_soap_request method" do
+      expect(test_instance).to receive(:get_customisable_headers).with(options) { customisable_headers }
+      expect(test_instance).to receive(:get_customisable_cookies).with(options) { customisable_cookies }
       allow(test_instance).to receive(:build_soap!) { req_double }
       expect(test_instance).to receive(:do_soap_request).with(
-        req_double, { response_class: Viewpoint::EWS::SOAP::EwsResponse, request_options: options }
+        req_double, {
+          response_class: Viewpoint::EWS::SOAP::EwsResponse,
+          options: { customisable_headers: customisable_headers, customisable_cookies: customisable_cookies }
+        }
       )
       subject
     end
   end
 
-  describe "#get_request_options" do
-
-    subject { test_instance.get_request_options(options) }
-
-    context "when a supported HTTP header is passed in" do
-      let(:anchor_mailbox) { "mailbox@example.com" }
-      let(:prefer_server_affinity) { true }
-      let(:options) {
-        {
-          anchor_mailbox: anchor_mailbox,
-          prefer_server_affinity: prefer_server_affinity
-        }
-      }
-
-      it "includes the HTTP header" do
-        result = subject
-
-        expect(result[:anchor_mailbox]).to eq(anchor_mailbox)
-        expect(result[:prefer_server_affinity]).to eq(prefer_server_affinity)
-      end
-    end
-
-    context "when a supported HTTP cookie is passed in" do
-      let(:backend_override_cookie) { "cookie" }
-      let(:options) { { backend_override_cookie: backend_override_cookie } }
-
-      it "includes the HTTP cookie" do
-        expect(subject[:backend_override_cookie]).to eq(backend_override_cookie)
-      end
-    end
+  describe "#get_customisable_cookies" do
+    subject { test_instance.get_customisable_cookies(options) }
   end
+
+  describe "#get_customisable_headers" do
+      subject { test_instance.get_customisable_headers(options) }
+  end
+
+  # describe "#get_request_options" do
+  #
+  #   subject { test_instance.get_request_options(options) }
+  #
+  #   context "when a supported HTTP header is passed in" do
+  #     let(:anchor_mailbox) { "mailbox@example.com" }
+  #     let(:prefer_server_affinity) { true }
+  #     let(:options) {
+  #       {
+  #         anchor_mailbox: anchor_mailbox,
+  #         prefer_server_affinity: prefer_server_affinity
+  #       }
+  #     }
+  #
+  #     it "includes the HTTP header" do
+  #       result = subject
+  #
+  #       expect(result[:anchor_mailbox]).to eq(anchor_mailbox)
+  #       expect(result[:prefer_server_affinity]).to eq(prefer_server_affinity)
+  #     end
+  #   end
+  #
+  #   context "when extra options are passed in" do
+  #     it "excludes the extra options" do
+  #
+  #     end
+  #   end
+
+    # context "when a supported HTTP cookie is passed in" do
+    #   let(:backend_override_cookie) { "cookie" }
+    #   let(:options) { { backend_override_cookie: backend_override_cookie } }
+    #
+    #   it "includes the HTTP cookie" do
+    #     expect(subject[:backend_override_cookie]).to eq(backend_override_cookie)
+    #   end
+    # end
+
+  # end
 end

--- a/spec/ews/soap/exchange_notification_spec.rb
+++ b/spec/ews/soap/exchange_notification_spec.rb
@@ -31,7 +31,8 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
       expect(test_instance).to receive(:do_soap_request).with(
         req_double, {
           response_class: Viewpoint::EWS::SOAP::EwsResponse,
-          options: { customisable_headers: customisable_headers, customisable_cookies: customisable_cookies }
+          customisable_headers: customisable_headers,
+          customisable_cookies: customisable_cookies
         }
       )
       subject
@@ -45,7 +46,8 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
         expect(test_instance).to receive(:do_soap_request).with(
           req_double, {
             response_class: Viewpoint::EWS::SOAP::EwsResponse,
-            options: { customisable_headers: {}, customisable_cookies: {} }
+            customisable_headers: {},
+            customisable_cookies: {}
           }
         )
         subject

--- a/spec/ews/soap/exchange_notification_spec.rb
+++ b/spec/ews/soap/exchange_notification_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Viewpoint::EWS::SOAP::ExchangeNotification do
+  class TestIncludeExchangeNotification
+    include Viewpoint::EWS::SOAP::ExchangeNotification
+  end
+
+  let(:test_instance) { TestIncludeExchangeNotification.new }
+  let(:folder) { { id: "some_id", change_key: "some_change_key" } }
+  let(:anchor_mailbox) { "mailbox@example.com" }
+  let(:prefer_server_affinity) { true }
+  let(:backend_override_cookie) { "cookie" }
+  let(:evtypes) { double(:evtypes) }
+  let(:subscriptions) {
+    {
+      anchor_mailbox: anchor_mailbox,
+      prefer_server_affinity: prefer_server_affinity,
+      backend_override_cookie: backend_override_cookie,
+      subscribe_to_all_folders: false,
+      folder_ids: [ { id: folder[:id], change_key: folder[:change_key] } ],
+      event_types: evtypes,
+      timeout: 30
+    }
+  }
+
+  describe "#stream_subscribe_folder" do
+    let(:options) {
+      {
+        anchor_mailbox: anchor_mailbox,
+        prefer_server_affinity: prefer_server_affinity,
+        backend_override_cookie: backend_override_cookie
+      }
+    }
+
+    subject { test_instance.stream_subscribe_folder(folder, evtypes, options: options) }
+
+    context "when options are passed in" do
+      it "includes anchor_mailbox, prefer_server_affinity and backend_override_cookie when calling the subscribe method" do
+        expect(test_instance).to receive(:subscribe).with([{streaming_subscription_request: subscriptions}])
+
+        subject
+      end
+    end
+  end
+
+  describe "#subscribe" do
+
+    subject { test_instance.subscribe(subscriptions) }
+
+    context "when anchor_mailbox is passed in" do
+
+      it "sets the anchor_mailbox header" do
+
+      end
+    end
+
+    context "when anchor_mailbox is not passed in" do
+
+      it "doesn't set the anchor_mailbox header" do
+        
+      end
+    end
+
+    context "when the prefer_server_affinity is passed in" do
+
+    end
+
+    context "when backend_override_cookie is passed in" do
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'viewpoint'
 require 'viewpoint/logging/config'
 require 'ostruct'
 require 'turn/autorun'
-require 'byebug'
 require_relative 'xml_matcher'
 
 RSpec.configure do |c|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'viewpoint'
 require 'viewpoint/logging/config'
 require 'ostruct'
 require 'turn/autorun'
+require 'byebug'
 require_relative 'xml_matcher'
 
 RSpec.configure do |c|


### PR DESCRIPTION
The get_streaming_request can take the following HTTP headers: `X-AnchorMailbox` and `X-PreferServerAffinity` and the following cookie `X-BackEndOverrideCookie`. Currently Viewpoint doesn't allow you to customise the HTTP headers and cookies included in the HTTP requests. So I'm modifying the `post` method inside `Viewpoint::EWS::Connection` to allow you to pass in a hash of custom headers and cookies which are then set when building the HTTP request. Only adding it to the POST method for now, as this is the only use case we currently have. 