### PR TITLE
Autodiscover get_user_settings: fixes and test refactoring

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -24,7 +24,7 @@ class Viewpoint::EWS::Connection
   attr_reader :endpoint, :hostname
   # @param [String] endpoint the URL of the web service.
   #   @example https://<site>/ews/Exchange.asmx
-  # @param [Hash] opts Misc config options (mostly for developement)
+  # @param [Hash] opts Misc config options (mostly for development)
   # @option opts [Fixnum] :ssl_verify_mode
   # @option opts [Fixnum] :receive_timeout override the default receive timeout
   #   seconds

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -171,7 +171,7 @@ module Viewpoint::EWS::SOAP
     def get_user_settings(opts)
       opts.merge!({
           server_version: server_version,
-          autodiscover_address: autodiscover_address
+          autodiscover_address: @connection.endpoint # you need to se the endpoint as the autodiscover address anyway
         }
       )
 
@@ -286,10 +286,6 @@ module Viewpoint::EWS::SOAP
       opts = { :server_version => server_version, :impersonation_type => impersonation_type, :impersonation_mail => impersonation_address }
       opts[:time_zone_context] = @time_zone_context if @time_zone_context
       EwsBuilder.new.build!(opts, &block)
-    end
-
-    def autodiscover_address
-      "https://#{connection.hostname}/autodiscover/autodiscover.svc"
     end
 
   end # class ExchangeWebService

--- a/spec/ews/soap/exchange_web_service_spec.rb
+++ b/spec/ews/soap/exchange_web_service_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe Viewpoint::EWS::SOAP::ExchangeWebService do
-  let(:connection) { Viewpoint::EWSClient.new("http://www.example.com", "test", "test") }
-  let(:ews_instance) { described_class.new(connection) }
+  let(:autodiscover_endpoint) { 'http://www.example.com/autodiscover/autodiscover.svc' }
+  let(:ews_client) { Viewpoint::EWSClient.new(autodiscover_endpoint, "test", "test") }
+  let(:ews_instance) { ews_client.ews }
   let(:opts) { { some_attribute: "some_value" } }
   let(:ews_builder_double) { double(:ews_builder) }
-  let(:autodiscover_address) { "http://example.com/autodiscover" }
   let(:soap_double) { double(:soap_double) }
 
   describe "#get_user_settings" do
@@ -13,13 +13,12 @@ describe Viewpoint::EWS::SOAP::ExchangeWebService do
     subject { ews_instance.get_user_settings(opts) }
 
     it "makes SOAP request" do
-      allow(ews_instance).to receive(:autodiscover_address) { autodiscover_address }
       expect(Viewpoint::EWS::SOAP::EwsBuilder).to receive(:new) { ews_builder_double }
       expect(ews_builder_double).to receive(:build_get_user_settings_soap).with(
         {
           some_attribute: "some_value",
           server_version: "Exchange2010",
-          autodiscover_address: autodiscover_address
+          autodiscover_address: autodiscover_endpoint
         }
       ).and_return(soap_double)
       expect(ews_instance).to receive(:do_soap_request).with(soap_double, {


### PR DESCRIPTION
It now works with the actual server, but you need to initialise the client to the actual autodiscover endpoint