### PR TITLE
Bugfix to enable GetItems to receive the correct parameters

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -1190,10 +1190,9 @@ module Viewpoint::EWS::SOAP
       when :item_id
         item_id!(item)
       when :occurrence_item_id
-        occurrence_item_id!(
-          item[:recurring_master_id], item[:change_key], item[:instance_index])
+        occurrence_item_id!(item)
       when :recurring_master_item_id
-        recurring_master_item_id!(item[:occurrence_id], item[:change_key])
+        recurring_master_item_id!(item)
       else
         raise EwsBadArgumentError, "Bad ItemId type. #{type}"
       end

--- a/lib/ews/types/item.rb
+++ b/lib/ews/types/item.rb
@@ -356,6 +356,7 @@ module Viewpoint::EWS::Types
           elems = a[:occurrence][:elems]
 
           h[DateTime.parse(elems.find{|e| e[:original_start]}[:original_start][:text])] = {
+            item_id: elems.find{|e| e[:item_id]}[:item_id][:attribs][:id],
             start: elems.find{|e| e[:start]}[:start][:text],
             end: elems.find{|e| e[:end]}[:end][:text]
           }

--- a/spec/unit/ews_soap_free_busy_response_spec.rb
+++ b/spec/unit/ews_soap_free_busy_response_spec.rb
@@ -110,7 +110,7 @@ EOS
     end
 
     it "the calendar_event_array should have one element" do
-      resp.calendar_event_array.should have(1).items
+      expect(resp.calendar_event_array.count).to eq 1
     end
   end
 


### PR DESCRIPTION
There are 2 changes for this PR. 

1. **Fix dispatch_item_id** method, so that we can correctly call the GetItems method, which requires us to pass in several parameters and currently it was not working. This issue has been fixed in a later version of viewpoint, with the exact same changes
[https://github.com/WinRb/Viewpoint/blob/master/lib/ews/soap/builders/ews_builder.rb#L1182](url)

2. **Add item_id** to the response hash, when calling 'modified_occurrences' on a recurring event. Currently, there is no existing calls to this method, and I am adding information to the response, so I consider this to be a safe, non-breaking change.
