### PR TITLE
removed Duplicated method & added sanity check

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -1349,7 +1349,7 @@ module Viewpoint::EWS::SOAP
 
     def accept_item!(opts)
       @nbuild[NS_EWS_TYPES].AcceptItem {
-        sensitivity!(opts)
+        sensitivity!(opts[:sensitivity]) if opts[:sensitivity]
         body!(opts) if opts[:text]
         reference_item_id!(opts)
       }
@@ -1357,7 +1357,7 @@ module Viewpoint::EWS::SOAP
 
     def tentatively_accept_item!(opts)
       @nbuild[NS_EWS_TYPES].TentativelyAcceptItem {
-        sensitivity!(opts)
+        sensitivity!(opts[:sensitivity]) if opts[:sensitivity]
         body!(opts) if opts[:text]
         reference_item_id!(opts)
       }
@@ -1365,14 +1365,10 @@ module Viewpoint::EWS::SOAP
 
     def decline_item!(opts)
       @nbuild[NS_EWS_TYPES].DeclineItem {
-        sensitivity!(opts)
+        sensitivity!(opts[:sensitivity]) if opts[:sensitivity]
         body!(opts) if opts[:text]
         reference_item_id!(opts)
       }
-    end
-
-    def sensitivity!(value)
-      nbuild[NS_EWS_TYPES].Sensitivity(value[:sensitivity])
     end
 
 private


### PR DESCRIPTION
A recent merge added in another method for `sensitivity!` which was passing in bad options, that was causing the v1 EWS integration to fail.