### PR TITLE
Adding additional logging and also adding 2016 Best practice headers

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -206,7 +206,7 @@ class Viewpoint::EWS::Connection
         'Return-Client-Request-Id' => 'true',
         'Send-Client-Latencies' => 'true',
         'Client-Request-Id' => (opts[:uniq_id] || SecureRandom.uuid),
-        'User-Agent' => 'JRNI EWS Integration'
+        'User-Agent' => @user_agent || 'Viewpoint EWS'
     }
     @httpcli.post_async(@endpoint, xmldoc, headers, request_body: xmldoc)
   end

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -24,7 +24,7 @@ class Viewpoint::EWS::Connection
   # This class returns both raw http response which is used to get cookies for grouping subscription
   EWSHttpResponse = Struct.new(:headers, :viewpoint_response)
 
-  attr_reader :endpoint, :hostname, :logger
+  attr_reader :endpoint, :hostname, :logger, :user_agent
   # @param [String] endpoint the URL of the web service.
   #   @example https://<site>/ews/Exchange.asmx
   # @param [Hash] opts Misc config options (mostly for development)
@@ -69,6 +69,10 @@ class Viewpoint::EWS::Connection
 
   def set_logger(logger:)
     @logger = logger
+  end
+
+  def set_user_agent(user_agent:)
+    @user_agent = user_agent
   end
 
   def hostname
@@ -155,7 +159,7 @@ class Viewpoint::EWS::Connection
         'Return-Client-Request-Id' => 'true',
         'Send-Client-Latencies' => 'true',
         'Client-Request-Id' => (options[:uniq_id] || SecureRandom.uuid),
-        'User-Agent' => 'JRNI EWS Integration'
+        'User-Agent' => @user_agent || 'Viewpoint EWS'
     }
 
     headers.merge!(custom_http_headers(options[:customisable_headers])) if options[:customisable_headers]

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -16,6 +16,7 @@
   limitations under the License.
 =end
 require 'httpclient'
+require 'securerandom'
 
 class Viewpoint::EWS::Connection
   include Viewpoint::EWS::ConnectionHelper

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -152,7 +152,7 @@ class Viewpoint::EWS::Connection
   # @return [String] If the request is successful (200) it returns the body of
   #   the response.
   def post(xmldoc, options: {})
-    log msg: "Making request for **#{options[:request_type]}** with uniq id of: **#{options[:uniq_id]}** with body: #{xmldoc.to_s.squish}"
+    log msg: "Making request for **#{options[:request_type]}** with uniq id of: **#{options[:uniq_id]}** with body: #{xmldoc.to_s.gsub(/\s+/, ' ')}"
 
     headers = {
         'Content-Type' => 'text/xml',
@@ -199,7 +199,7 @@ class Viewpoint::EWS::Connection
   # Send a asynchronous POST to the web service which creates a connection for sending/receiving data
   # @return [HTTPClient::Connection] HTTPClient::Connection
   def post_async(xmldoc, opts: {})
-    log msg: "Making request for #{opts[:request_type]} with uniq id of: #{opts[:uniq_id]}, with body: #{xmldoc.to_s.squish}"
+    log msg: "Making request for #{opts[:request_type]} with uniq id of: #{opts[:uniq_id]}, with body: #{xmldoc.to_s.gsub(/\s+/, ' ')}"
     headers = {
         'Content-Type' => 'text/xml',
         'Return-Client-Request-Id' => 'true',

--- a/lib/ews/ews_client.rb
+++ b/lib/ews/ews_client.rb
@@ -37,6 +37,7 @@ class Viewpoint::EWSClient
   #   Viewpoint::EWS::SOAP::ExchangeWebService.
   # @option opts [Object] :http_class specify an alternate HTTP connection class.
   # @option opts [Hash] :http_opts options to pass to the connection
+  # Pass in the rails application?
   def initialize(endpoint, username, password, opts = {})
     # dup all. @see ticket https://github.com/zenchild/Viewpoint/issues/68
     @endpoint = endpoint.dup
@@ -46,6 +47,7 @@ class Viewpoint::EWSClient
     http_klass = opts[:http_class] || Viewpoint::EWS::Connection
     con = http_klass.new(endpoint, opts[:http_opts] || {})
     con.set_auth @username, password
+    con.set_logger(logger: opts[:logger_opts][:logger]) if opts.has_key?(:logger_opts)
     @ews = SOAP::ExchangeWebService.new(con, opts)
   end
 

--- a/lib/ews/ews_client.rb
+++ b/lib/ews/ews_client.rb
@@ -47,8 +47,8 @@ class Viewpoint::EWSClient
     http_klass = opts[:http_class] || Viewpoint::EWS::Connection
     con = http_klass.new(endpoint, opts[:http_opts] || {})
     con.set_auth @username, password
-    con.set_logger(logger: opts[:logger_opts][:logger]) if opts.has_key?(:logger_opts)
-    con.set_user_agent(user_agent: options[:user_agent]) if opts.has_key?(:user_agent)
+    con.logger = opts[:logger_opts][:logger] if opts.has_key?(:logger_opts)
+    con.user_agent = opts[:user_agent]  if opts.has_key?(:user_agent)
     @ews = SOAP::ExchangeWebService.new(con, opts)
   end
 

--- a/lib/ews/ews_client.rb
+++ b/lib/ews/ews_client.rb
@@ -48,6 +48,7 @@ class Viewpoint::EWSClient
     con = http_klass.new(endpoint, opts[:http_opts] || {})
     con.set_auth @username, password
     con.set_logger(logger: opts[:logger_opts][:logger]) if opts.has_key?(:logger_opts)
+    con.set_user_agent(user_agent: options[:user_agent]) if opts.has_key?(:user_agent)
     @ews = SOAP::ExchangeWebService.new(con, opts)
   end
 

--- a/lib/ews/soap/exchange_availability.rb
+++ b/lib/ews/soap/exchange_availability.rb
@@ -27,7 +27,12 @@ module Viewpoint::EWS::SOAP
         }
         end
       end
-      do_soap_request(req, response_class: EwsSoapAvailabilityResponse)
+      options = {
+          request_type: 'Get User OOF Settings',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapAvailabilityResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Sets a mailbox user's Out of Office (OOF) settings and message.
@@ -54,7 +59,12 @@ module Viewpoint::EWS::SOAP
         }
         end
       end
-      do_soap_request(req, response_class: EwsSoapAvailabilityResponse)
+      options = {
+          request_type: 'Set User OOF Settings',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapAvailabilityResponse
+      }
+      do_soap_request(req, options)
     end
 
   end #ExchangeAvailability

--- a/lib/ews/soap/exchange_availability.rb
+++ b/lib/ews/soap/exchange_availability.rb
@@ -29,7 +29,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get User OOF Settings',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapAvailabilityResponse
       }
       do_soap_request(req, options)
@@ -61,7 +60,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Set User OOF Settings',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapAvailabilityResponse
       }
       do_soap_request(req, options)

--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -52,7 +52,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Find Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -92,7 +91,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -160,7 +158,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Create Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -218,7 +215,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Update Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -264,7 +260,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Delete Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -310,7 +305,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Move Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -356,7 +350,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Copy Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -400,7 +393,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Send Item',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -426,7 +418,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Export Items',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -462,8 +453,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Create Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Create Folder'
       }
       do_soap_request(req, options)
     end
@@ -516,8 +506,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Delete Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Delete Folder'
       }
       do_soap_request(req, options)
     end
@@ -559,8 +548,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Find Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Find Folder'
       }
       do_soap_request(req, options)
     end
@@ -598,8 +586,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Find Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Find Folder'
       }
       do_soap_request(req, options)
     end
@@ -623,8 +610,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Move Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Move Folder'
       }
       do_soap_request(req, options)
     end
@@ -655,8 +641,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Update Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Update Folder'
       }
       do_soap_request(req, options)
     end
@@ -689,8 +674,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Empty Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Empty Folder'
       }
       do_soap_request(req, options)
     end
@@ -721,8 +705,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Get Attachment',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Get Attachment'
       }
       do_soap_request(req, options)
     end
@@ -766,7 +749,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Create Attachment',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -801,8 +783,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Expand Distribution List',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Expand Distribution List'
       }
       do_soap_request(req, options)
     end
@@ -836,8 +817,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Resolve Names',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Resolve Names'
       }
       do_soap_request(req, options)
     end
@@ -870,7 +850,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Convert Ids',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)

--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -477,8 +477,7 @@ module Viewpoint::EWS::SOAP
         end
       end
       options = {
-          request_type: 'Copy Folder',
-          uniq_id: SecureRandom.uuid
+          request_type: 'Copy Folder'
       }
       do_soap_request(req, options)
     end

--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -50,7 +50,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Find Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Gets items from the Exchange store
@@ -85,7 +90,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Get Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Defines a request to create an item in the Exchange store.
@@ -148,7 +158,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Create Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Used to modify the properties of an existing item in the Exchange store
@@ -201,7 +216,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Update Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Delete an item from a mailbox in the Exchange store
@@ -242,7 +262,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Delete Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Used to move one or more items to a single destination folder.
@@ -283,7 +308,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Move Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Copies items and puts the items in a different folder
@@ -324,7 +354,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Copy Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Used to send e-mail messages that are located in the Exchange store.
@@ -363,7 +398,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Send Item',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Export items as a base64 string
@@ -384,7 +424,12 @@ module Viewpoint::EWS::SOAP
       builder.export_item_ids!(ids[:item_ids])
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Export Items',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # ------------- Folder Operations ------------
@@ -416,7 +461,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Create Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Defines a request to copy folders in the Exchange store
@@ -437,7 +486,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Copy Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Deletes folders from a mailbox.
@@ -462,7 +515,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Delete Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Find subfolders of an identified folder
@@ -501,7 +558,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Find Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Gets folders from the Exchange store
@@ -536,7 +597,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Find Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Defines a request to move folders in the Exchange store
@@ -557,7 +622,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Move Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Update properties for a specified folder
@@ -585,7 +654,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Update Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Empties folders in a mailbox.
@@ -615,7 +688,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Empty Folder',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # ----------- Attachment Operations ----------
@@ -643,7 +720,11 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Get Attachment',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Creates either an item or file attachment and attaches it to the specified item.
@@ -683,7 +764,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Create Attachment',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
 
@@ -714,7 +800,11 @@ module Viewpoint::EWS::SOAP
         }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Expand Distribution List',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Resolve ambiguous e-mail addresses and display names
@@ -745,7 +835,11 @@ module Viewpoint::EWS::SOAP
         }
         end
       end
-      do_soap_request(req)
+      options = {
+          request_type: 'Resolve Names',
+          uniq_id: SecureRandom.uuid
+      }
+      do_soap_request(req, options)
     end
 
     # Converts item and folder identifiers between formats.
@@ -774,7 +868,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Convert Ids',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
   end #ExchangeDataServices

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -71,8 +71,7 @@ module Viewpoint::EWS::SOAP
         response_class: EwsResponse,
         customisable_headers: customisable_headers,
         customisable_cookies: customisable_cookies,
-        request_type: 'Subscribe',
-        uniq_id: SecureRandom.uuid,
+        request_type: 'Subscribe'
       })
       do_soap_request(req, opts)
     end
@@ -101,7 +100,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Unsubscribe',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsResponse
       }
       do_soap_request(req, options)
@@ -151,7 +149,6 @@ module Viewpoint::EWS::SOAP
       # TODO: Once do_soap_request_async support raw_response, returns GetStreamingEventResponse results
       options = {
           request_type: 'Get Streaming Events',
-          uniq_id: SecureRandom.uuid,
           raw_response: true
       }
       do_soap_request_async(req, options)

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -70,9 +70,10 @@ module Viewpoint::EWS::SOAP
       opts = options.merge({
         response_class: EwsResponse,
         customisable_headers: customisable_headers,
-        customisable_cookies: customisable_cookies
+        customisable_cookies: customisable_cookies,
+        request_type: 'Subscribe',
+        uniq_id: SecureRandom.uuid,
       })
-
       do_soap_request(req, opts)
     end
 
@@ -98,7 +99,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Unsubscribe',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Used by pull subscription clients to request notifications from the Client Access server
@@ -117,7 +123,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      options = {
+          request_type: 'Get Events',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Used by stream subscription clients to create connection to the Client Access server
@@ -138,7 +149,12 @@ module Viewpoint::EWS::SOAP
       end
 
       # TODO: Once do_soap_request_async support raw_response, returns GetStreamingEventResponse results
-      do_soap_request_async(req, raw_response: true)
+      options = {
+          request_type: 'Get Streaming Events',
+          uniq_id: SecureRandom.uuid,
+          raw_response: true
+      }
+      do_soap_request_async(req, options)
     end
 
 

--- a/lib/ews/soap/exchange_time_zones.rb
+++ b/lib/ews/soap/exchange_time_zones.rb
@@ -17,7 +17,12 @@ module Viewpoint::EWS::SOAP
           builder.get_server_time_zones!(full: full, ids: ids)
         end
       end
-      result = do_soap_request req, response_class: EwsSoapResponse
+      options = {
+          request_type: 'Get user Timezones',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapResponse
+      }
+      result = do_soap_request(req, options)
 
       if result.success?
         zones = []

--- a/lib/ews/soap/exchange_time_zones.rb
+++ b/lib/ews/soap/exchange_time_zones.rb
@@ -19,7 +19,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get user Timezones',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapResponse
       }
       result = do_soap_request(req, options)

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -44,6 +44,7 @@ module Viewpoint::EWS::SOAP
       @no_auto_deepen_behavior = :raise
       @impersonation_type = ""
       @impersonation_address = ""
+      @logger = opts[:logger]
     end
 
     def delete_attachment
@@ -164,8 +165,12 @@ module Viewpoint::EWS::SOAP
         }
         end
       end
-
-      do_soap_request(req, response_class: EwsSoapFreeBusyResponse)
+      options = {
+          request_type: 'Get User Availablity',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapFreeBusyResponse
+      }
+      do_soap_request(req, options)
     end
 
     def get_user_settings(opts)
@@ -176,7 +181,12 @@ module Viewpoint::EWS::SOAP
       )
 
       req = EwsBuilder.new.build_get_user_settings_soap(opts)
-      do_soap_request(req, response_class: EwsSoapGetUserSettingsResponse)
+      options = {
+          request_type: 'Get User Settings',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapGetUserSettingsResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Gets the rooms that are in the specified room distribution list
@@ -192,7 +202,12 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsSoapRoomResponse)
+      options = {
+          request_type: 'Get Rooms',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapRoomResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Gets the room lists that are available within the Exchange organization.
@@ -204,7 +219,12 @@ module Viewpoint::EWS::SOAP
           builder.room_lists!
         end
       end
-      do_soap_request(req, response_class: EwsSoapRoomlistResponse)
+      options = {
+          request_type: 'Get Rooms Lists',
+          uniq_id: SecureRandom.uuid,
+          response_class: EwsSoapRoomlistResponse
+      }
+      do_soap_request(req, options)
     end
 
     # Send the SOAP request to the endpoint and parse it.
@@ -214,6 +234,9 @@ module Viewpoint::EWS::SOAP
     # @option opts [Boolean] :raw_response if true do not parse and return
     #   the raw response string.
     def do_soap_request(soapmsg, opts = {})
+      #  Most of the requests seem to be non async, so we can log here when we are making the request
+      # or we can do it inside the connection
+      @logger.info "Making requests to exchange, with options #{opts}"
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
         ----------------

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -167,7 +167,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get User Availablity',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapFreeBusyResponse
       }
       do_soap_request(req, options)
@@ -183,7 +182,6 @@ module Viewpoint::EWS::SOAP
       req = EwsBuilder.new.build_get_user_settings_soap(opts)
       options = {
           request_type: 'Get User Settings',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapGetUserSettingsResponse
       }
       do_soap_request(req, options)
@@ -204,7 +202,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get Rooms',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapRoomResponse
       }
       do_soap_request(req, options)
@@ -221,7 +218,6 @@ module Viewpoint::EWS::SOAP
       end
       options = {
           request_type: 'Get Rooms Lists',
-          uniq_id: SecureRandom.uuid,
           response_class: EwsSoapRoomlistResponse
       }
       do_soap_request(req, options)

--- a/spec/ews/connection_spec.rb
+++ b/spec/ews/connection_spec.rb
@@ -21,9 +21,10 @@ describe Viewpoint::EWS::Connection do
 
     context "when customisable headers are passed in" do
       let(:options) { { customisable_headers: customisable_headers } }
-      let(:expected_headers) { {'Content-Type' => 'text/xml', 'Return-Client-Request-Id' => 'true', 'Send-Client-Latencies' => 'true'}.merge!(customisable_headers) }
+      let(:expected_headers) { {'Content-Type' => 'text/xml', 'Return-Client-Request-Id' => 'true', 'Send-Client-Latencies' => 'true', 'Client-Request-Id' => 'test', 'User-Agent' => 'Viewpoint EWS'}.merge!(customisable_headers) }
 
       it "merges the custom HTTP headers to the existing headers" do
+        expect(SecureRandom).to receive(:uuid).and_return("test")
         expect(connection).to receive(:custom_http_headers) { customisable_headers }
         expect(connection.instance_variable_get(:@httpcli)).to receive(:post)
           .with(endpoint, xmldoc, expected_headers)
@@ -43,10 +44,11 @@ describe Viewpoint::EWS::Connection do
     end
 
     context "when no customisable cookies are passed in" do
-      let(:expected_headers) { {'Content-Type' => 'text/xml', 'Return-Client-Request-Id' => 'true', 'Send-Client-Latencies' => 'true'} }
+      let(:expected_headers) { {'Content-Type' => 'text/xml', 'Return-Client-Request-Id' => 'true', 'Send-Client-Latencies' => 'true','Client-Request-Id' => 'test', 'User-Agent' => 'Viewpoint EWS'} }
 
       it "sets only the default headers" do
         expect(connection).not_to receive(:custom_http_headers)
+        expect(SecureRandom).to receive(:uuid).and_return("test")
         expect(connection.instance_variable_get(:@httpcli)).to receive(:post)
           .with(endpoint, xmldoc, expected_headers)
 

--- a/spec/ews/soap/exchange_notification_spec.rb
+++ b/spec/ews/soap/exchange_notification_spec.rb
@@ -25,6 +25,7 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
     subject { test_instance.subscribe(subscriptions, options: options) }
 
     it "passes the customisable_cookies and customisable_headers options to the do_soap_request method" do
+      expect(SecureRandom).to receive(:uuid).and_return('test')
       expect(test_instance).to receive(:get_customisable_headers).with(options) { customisable_headers }
       expect(test_instance).to receive(:get_customisable_cookies).with(options) { customisable_cookies }
       allow(test_instance).to receive(:build_soap!) { req_double }
@@ -33,7 +34,9 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
           anchor_mailbox: "mailbox@example.com",
           response_class: Viewpoint::EWS::SOAP::EwsResponse,
           customisable_headers: customisable_headers,
-          customisable_cookies: customisable_cookies
+          customisable_cookies: customisable_cookies,
+          request_type: 'Subscribe',
+          uniq_id: 'test'
         }
       )
       subject
@@ -41,6 +44,7 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
 
     context "when get_customisable_headers and get_customisable_cookies return nil" do
       it "passes empty headers and cookies hashes to the do_soap_request method" do
+        expect(SecureRandom).to receive(:uuid).and_return('test')
         expect(test_instance).to receive(:get_customisable_headers).with(options) { nil }
         expect(test_instance).to receive(:get_customisable_cookies).with(options) { nil }
         allow(test_instance).to receive(:build_soap!) { req_double }
@@ -49,7 +53,9 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
             anchor_mailbox: "mailbox@example.com",
             response_class: Viewpoint::EWS::SOAP::EwsResponse,
             customisable_headers: {},
-            customisable_cookies: {}
+            customisable_cookies: {},
+            request_type: 'Subscribe',
+            uniq_id: 'test'
           }
         )
         subject

--- a/spec/ews/soap/exchange_notification_spec.rb
+++ b/spec/ews/soap/exchange_notification_spec.rb
@@ -25,7 +25,6 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
     subject { test_instance.subscribe(subscriptions, options: options) }
 
     it "passes the customisable_cookies and customisable_headers options to the do_soap_request method" do
-      expect(SecureRandom).to receive(:uuid).and_return('test')
       expect(test_instance).to receive(:get_customisable_headers).with(options) { customisable_headers }
       expect(test_instance).to receive(:get_customisable_cookies).with(options) { customisable_cookies }
       allow(test_instance).to receive(:build_soap!) { req_double }
@@ -35,8 +34,7 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
           response_class: Viewpoint::EWS::SOAP::EwsResponse,
           customisable_headers: customisable_headers,
           customisable_cookies: customisable_cookies,
-          request_type: 'Subscribe',
-          uniq_id: 'test'
+          request_type: 'Subscribe'
         }
       )
       subject
@@ -44,7 +42,6 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
 
     context "when get_customisable_headers and get_customisable_cookies return nil" do
       it "passes empty headers and cookies hashes to the do_soap_request method" do
-        expect(SecureRandom).to receive(:uuid).and_return('test')
         expect(test_instance).to receive(:get_customisable_headers).with(options) { nil }
         expect(test_instance).to receive(:get_customisable_cookies).with(options) { nil }
         allow(test_instance).to receive(:build_soap!) { req_double }
@@ -54,8 +51,7 @@ describe Viewpoint::EWS::SOAP::ExchangeNotification do
             response_class: Viewpoint::EWS::SOAP::EwsResponse,
             customisable_headers: {},
             customisable_cookies: {},
-            request_type: 'Subscribe',
-            uniq_id: 'test'
+            request_type: 'Subscribe'
           }
         )
         subject

--- a/spec/ews/soap/exchange_web_service_spec.rb
+++ b/spec/ews/soap/exchange_web_service_spec.rb
@@ -13,7 +13,6 @@ describe Viewpoint::EWS::SOAP::ExchangeWebService do
     subject { ews_instance.get_user_settings(opts) }
 
     it "makes SOAP request" do
-      expect(SecureRandom).to receive(:uuid) { 'test' }
       expect(Viewpoint::EWS::SOAP::EwsBuilder).to receive(:new) { ews_builder_double }
       expect(ews_builder_double).to receive(:build_get_user_settings_soap).with(
         {
@@ -24,8 +23,7 @@ describe Viewpoint::EWS::SOAP::ExchangeWebService do
       ).and_return(soap_double)
       expect(ews_instance).to receive(:do_soap_request).with(soap_double, {
         response_class: Viewpoint::EWS::SOAP::EwsSoapGetUserSettingsResponse,
-        request_type: 'Get User Settings',
-        uniq_id: 'test'
+        request_type: 'Get User Settings'
         }
       )
 

--- a/spec/ews/soap/exchange_web_service_spec.rb
+++ b/spec/ews/soap/exchange_web_service_spec.rb
@@ -13,6 +13,7 @@ describe Viewpoint::EWS::SOAP::ExchangeWebService do
     subject { ews_instance.get_user_settings(opts) }
 
     it "makes SOAP request" do
+      expect(SecureRandom).to receive(:uuid) { 'test' }
       expect(Viewpoint::EWS::SOAP::EwsBuilder).to receive(:new) { ews_builder_double }
       expect(ews_builder_double).to receive(:build_get_user_settings_soap).with(
         {
@@ -22,7 +23,9 @@ describe Viewpoint::EWS::SOAP::ExchangeWebService do
         }
       ).and_return(soap_double)
       expect(ews_instance).to receive(:do_soap_request).with(soap_double, {
-        response_class: Viewpoint::EWS::SOAP::EwsSoapGetUserSettingsResponse
+        response_class: Viewpoint::EWS::SOAP::EwsSoapGetUserSettingsResponse,
+        request_type: 'Get User Settings',
+        uniq_id: 'test'
         }
       )
 

--- a/spec/unit/ews_folder_operations_spec.rb
+++ b/spec/unit/ews_folder_operations_spec.rb
@@ -7,11 +7,12 @@ describe "Operations on Exchange Data Services" do
     @ews = Viewpoint::EWS::SOAP::ExchangeWebService.new con,
       {:server_version => Viewpoint::EWS::SOAP::VERSION_2010_SP2}
     @ews.stub(:do_soap_request)
+    allow(SecureRandom).to receive(:uuid) { 'test' }
   end
 
   it "generates CreateFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("create_folder", :request)))
+      with(match_xml(load_soap("create_folder", :request)), { request_type: 'Create Folder', uniq_id: 'test'})
 
     fname = "Test Folder"
     opts = {:parent_folder_id => {:id => :msgfolderroot},
@@ -21,7 +22,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates CopyFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("copy_folder", :request)))
+      with(match_xml(load_soap("copy_folder", :request)), { request_type: 'Copy Folder', uniq_id: 'test'})
 
     tofid = {:id => 'dest_folder_id'}
     @ews.copy_folder tofid, [:id => 'src_folder_id']
@@ -29,7 +30,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates DeleteFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("delete_folder", :request)))
+      with(match_xml(load_soap("delete_folder", :request)), { request_type: 'Delete Folder', uniq_id: 'test'})
 
     fid = "test_folder_id"
     opts = {:folder_ids => [id: fid]}
@@ -39,7 +40,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates FindFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("find_folder", :request)))
+      with(match_xml(load_soap("find_folder", :request)),{ request_type: 'Find Folder', uniq_id: 'test'})
 
     fname = "Test Folder"
     opts = {:restriction =>
@@ -66,7 +67,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates GetFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("get_folder", :request)))
+      with(match_xml(load_soap("get_folder", :request)), { request_type: 'Find Folder', uniq_id: 'test'})
 
     opts = { :folder_ids => [{:id => :msgfolderroot}],
       :folder_shape => {:base_shape => 'Default'} }
@@ -92,7 +93,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates MoveFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("move_folder", :request)))
+      with(match_xml(load_soap("move_folder", :request)), { request_type: 'Move Folder', uniq_id: 'test'})
 
     tofid = {:id => 'dest_folder_id'}
     @ews.move_folder tofid, [:id => 'src_folder_id']
@@ -100,7 +101,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates EmptyFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("empty_folder", :request)))
+      with(match_xml(load_soap("empty_folder", :request)), { request_type: 'Empty Folder', uniq_id: 'test'})
 
     fid = "test_folder_id"
     opts = {:folder_ids => [id: fid]}

--- a/spec/unit/ews_folder_operations_spec.rb
+++ b/spec/unit/ews_folder_operations_spec.rb
@@ -7,12 +7,11 @@ describe "Operations on Exchange Data Services" do
     @ews = Viewpoint::EWS::SOAP::ExchangeWebService.new con,
       {:server_version => Viewpoint::EWS::SOAP::VERSION_2010_SP2}
     @ews.stub(:do_soap_request)
-    allow(SecureRandom).to receive(:uuid) { 'test' }
   end
 
   it "generates CreateFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("create_folder", :request)), { request_type: 'Create Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("create_folder", :request)), { request_type: 'Create Folder'})
 
     fname = "Test Folder"
     opts = {:parent_folder_id => {:id => :msgfolderroot},
@@ -22,7 +21,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates CopyFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("copy_folder", :request)), { request_type: 'Copy Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("copy_folder", :request)), { request_type: 'Copy Folder'})
 
     tofid = {:id => 'dest_folder_id'}
     @ews.copy_folder tofid, [:id => 'src_folder_id']
@@ -30,7 +29,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates DeleteFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("delete_folder", :request)), { request_type: 'Delete Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("delete_folder", :request)), { request_type: 'Delete Folder'})
 
     fid = "test_folder_id"
     opts = {:folder_ids => [id: fid]}
@@ -40,7 +39,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates FindFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("find_folder", :request)),{ request_type: 'Find Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("find_folder", :request)),{ request_type: 'Find Folder'})
 
     fname = "Test Folder"
     opts = {:restriction =>
@@ -67,7 +66,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates GetFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("get_folder", :request)), { request_type: 'Find Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("get_folder", :request)), { request_type: 'Find Folder'})
 
     opts = { :folder_ids => [{:id => :msgfolderroot}],
       :folder_shape => {:base_shape => 'Default'} }
@@ -93,7 +92,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates MoveFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("move_folder", :request)), { request_type: 'Move Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("move_folder", :request)), { request_type: 'Move Folder'})
 
     tofid = {:id => 'dest_folder_id'}
     @ews.move_folder tofid, [:id => 'src_folder_id']
@@ -101,7 +100,7 @@ describe "Operations on Exchange Data Services" do
 
   it "generates EmptyFolder XML" do
     @ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("empty_folder", :request)), { request_type: 'Empty Folder', uniq_id: 'test'})
+      with(match_xml(load_soap("empty_folder", :request)), { request_type: 'Empty Folder'})
 
     fid = "test_folder_id"
     opts = {:folder_ids => [id: fid]}


### PR DESCRIPTION
One of the parts of 2016 best practices is to pass a uniq id and a custom user agent when communicating with the EWS API.
This change adds them but also makes it possible to log the statements easier.

when initialised we can now pass in a logger (i.e Rails.logger) and it will log before and after making a request (with the exception of after with the get streaming notifications as it is an async request)
it makes simpler to track which requests went with which id and which returned with which id..

For example:
![Screenshot 2019-10-07 at 14 47 32](https://user-images.githubusercontent.com/2750491/66327227-6722bb00-e922-11e9-8bd0-3b296f38bfa5.png)
