### PR TITLE
add-atendee-to-calendaritem - adds methods to find attendees

### DIFF
--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -135,7 +135,6 @@ module Viewpoint::EWS::Types
         email_address: attendee.email_address
       }
     end
-  end
 
     private
 

--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -118,6 +118,24 @@ module Viewpoint::EWS::Types
       iso8601_duration_to_seconds(duration)
     end
 
+    def has_attendees?
+      required_attendees.present? || optional_attendees.present?
+    end
+
+    def attendees
+      {
+        required: required_attendees.map { |attendee| attendee_attributes(attendee) },
+        optional: optional_attendees.map { |attendee| attendee_attributes(attendee) }
+      }
+    end
+
+    def attendee_attributes(attendee)
+      {
+        name: attendee.name,
+        email_address: attendee.email_address
+      }
+    end
+  end
 
     private
 


### PR DESCRIPTION
Adds methods that we're previously used in the lib/integrations/calendar/exchange/calendar_item.rb class to here so we wont have to extend ews_items everywhere.